### PR TITLE
fix BSOD when in Windows

### DIFF
--- a/rootdir/init.usb.rc
+++ b/rootdir/init.usb.rc
@@ -25,7 +25,7 @@ on property:sys.usb.config=none && property:sys.usb.configfs=0
 on property:sys.usb.config=adb && property:sys.usb.configfs=0
     write /sys/class/android_usb/android0/enable 0
     write /sys/class/android_usb/android0/idVendor 18d1
-    write /sys/class/android_usb/android0/idProduct 4EE7
+    write /sys/class/android_usb/android0/idProduct D002
     write /sys/class/android_usb/android0/functions ${sys.usb.config}
     write /sys/class/android_usb/android0/enable 1
     start adbd


### PR DESCRIPTION
USB ID's changed to fix BSOD in Windows.
